### PR TITLE
feat(form-field-error): add niceSignalFormFieldError directive for Angular signal forms

### DIFF
--- a/src/dev-app/app/app.component.ts
+++ b/src/dev-app/app/app.component.ts
@@ -7,7 +7,7 @@ import { MatInput } from "@angular/material/input";
 import { MatOption, MatSelect } from "@angular/material/select";
 import { NiceChipListDirective } from "@recursyve/ngx-material-components/chip-list";
 import { NiceDropzone, NiceDropzoneFileSizeConfig, NiceDropzoneImageConfig } from "@recursyve/ngx-material-components/dropzone";
-import { NiceFormFieldErrorDirective } from "@recursyve/ngx-material-components/form-field-error";
+import { NiceFormFieldErrorDirective, NiceSignalFormFieldErrorDirective } from "@recursyve/ngx-material-components/form-field-error";
 import { NiceLoadingDirective } from "@recursyve/ngx-material-components/loading";
 import {
     NiceAsyncTypeahead,
@@ -16,6 +16,7 @@ import {
 } from "@recursyve/ngx-material-components/typeahead";
 import { NiceChipListItems } from "../../material-components/chip-list/items/chip-list-items";
 import { ColorsTypeaheadResourceProvider, NiceColors } from "./providers/colors-typeahead-resource.provider";
+import { FormField, form, required, maxLength, minLength, email, submit } from "@angular/forms/signals";
 
 @Component({
     selector: "nice-root",
@@ -32,6 +33,8 @@ import { ColorsTypeaheadResourceProvider, NiceColors } from "./providers/colors-
         NiceAsyncTypeahead,
         NiceLoadingDirective,
         NiceFormFieldErrorDirective,
+        NiceSignalFormFieldErrorDirective,
+        FormField,
         MatInput,
         NiceChipListDirective,
         NiceChipListItems
@@ -95,6 +98,15 @@ export class AppComponent implements AfterViewInit {
         count: this._fb.control(0, [Validators.required, Validators.min(1)]),
     });
 
+    public readonly signalFormModel = signal({ name: "", email: "" });
+    public readonly signalForm = form(this.signalFormModel, (schemaPath) => {
+        required(schemaPath.name);
+        maxLength(schemaPath.name, 10);
+        required(schemaPath.email);
+        minLength(schemaPath.email, 5);
+        email(schemaPath.email);
+    });
+
     public chipListFormGroup = this._fb.group({
         chipList: this._fb.control(null)
     });
@@ -148,5 +160,11 @@ export class AppComponent implements AfterViewInit {
 
     public disableDropzone(): void {
         this.dropzoneFormGroup.controls.dropzone.disable();
+    }
+
+    public submitSignalForm(): void {
+        submit(this.signalForm, async () => {
+            console.log("Signal form submitted:", this.signalFormModel());
+        });
     }
 }

--- a/src/dev-app/app/app.component.ts
+++ b/src/dev-app/app/app.component.ts
@@ -16,7 +16,7 @@ import {
 } from "@recursyve/ngx-material-components/typeahead";
 import { NiceChipListItems } from "../../material-components/chip-list/items/chip-list-items";
 import { ColorsTypeaheadResourceProvider, NiceColors } from "./providers/colors-typeahead-resource.provider";
-import { FormField, form, required, maxLength, minLength, email, submit } from "@angular/forms/signals";
+import { email, FormField, form, maxLength, minLength, required, submit, validate } from "@angular/forms/signals";
 
 @Component({
     selector: "nice-root",
@@ -102,6 +102,13 @@ export class AppComponent implements AfterViewInit {
     public readonly signalForm = form(this.signalFormModel, (schemaPath) => {
         required(schemaPath.name);
         maxLength(schemaPath.name, 10);
+        validate(schemaPath.name, ({ value }) => {
+            if (value() === "admin") {
+                return { kind: "reserved", reservedValue: value() };
+            }
+
+            return undefined;
+        });
         required(schemaPath.email);
         minLength(schemaPath.email, 5);
         email(schemaPath.email);

--- a/src/dev-app/app/app.config.ts
+++ b/src/dev-app/app/app.config.ts
@@ -20,6 +20,12 @@ export const appConfig: ApplicationConfig = {
         provideFormFieldError({
             translater: {
                 useFactory: () => (key) => key
+            },
+            signalErrorTransformers: {
+                reserved: (_, details) => ({
+                    key: "reserved",
+                    params: { value: String(details["reservedValue"] ?? "") }
+                })
             }
         }),
         provideDropzone()

--- a/src/dev-app/app/app.config.ts
+++ b/src/dev-app/app/app.config.ts
@@ -7,6 +7,24 @@ import { provideFormFieldError } from "@recursyve/ngx-material-components/form-f
 
 import { routes } from "./app.routes";
 
+const demoErrorMessages: Record<string, string> = {
+    "errors.required": "This field is required.",
+    "errors.min": "Value must be at least {{min}}.",
+    "errors.minlength": "Minimum length is {{value}} characters.",
+    "errors.maxlength": "Maximum length is {{value}} characters.",
+    "errors.email": "Invalid email address.",
+    "errors.reserved": "The username \"{{value}}\" is reserved."
+};
+
+function demoTranslater(key: string, params?: Record<string, string>): string {
+    const template = demoErrorMessages[key] ?? key;
+
+    return Object.entries(params ?? {}).reduce(
+        (message, [name, value]) => message.replaceAll(`{{${name}}}`, value),
+        template
+    );
+}
+
 export const appConfig: ApplicationConfig = {
     providers: [
         provideZoneChangeDetection({ eventCoalescing: true }),
@@ -19,7 +37,7 @@ export const appConfig: ApplicationConfig = {
         }),
         provideFormFieldError({
             translater: {
-                useFactory: () => (key) => key
+                useFactory: () => demoTranslater
             },
             signalErrorTransformers: {
                 reserved: (_, details) => ({

--- a/src/dev-app/app/app.template.html
+++ b/src/dev-app/app/app.template.html
@@ -115,6 +115,22 @@
         </mat-form-field>
     </div>
 
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: fit-content;">
+        <h4 style="padding-top: 48px">Signal forms — niceSignalFormFieldError</h4>
+
+        <mat-form-field appearance="outline" niceSignalFormFieldError>
+            <mat-label>Name</mat-label>
+            <input matInput [formField]="signalForm.name" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" niceSignalFormFieldError>
+            <mat-label>Email</mat-label>
+            <input matInput [formField]="signalForm.email" />
+        </mat-form-field>
+
+        <button mat-flat-button (click)="submitSignalForm()">Submit signal form</button>
+    </div>
+
     <div
         style="width: 750px; padding-top: 64px"
         [formGroup]="chipListFormGroup"

--- a/src/material-components/form-field-error/form-field-error-display.ts
+++ b/src/material-components/form-field-error/form-field-error-display.ts
@@ -1,0 +1,63 @@
+import { ComponentRef, ElementRef, ViewContainerRef } from "@angular/core";
+import { NiceTranslater } from "@recursyve/ngx-material-components/common";
+
+import { NiceFormErrorComponent } from "./form-field-error";
+
+export class FormFieldErrorDisplay {
+    private ref: ComponentRef<NiceFormErrorComponent> | null = null;
+
+    constructor(
+        private readonly elementRef: ElementRef<HTMLElement>,
+        private readonly viewContainerRef: ViewContainerRef,
+        private readonly translater: NiceTranslater
+    ) {}
+
+    public setError(text: string, params: Record<string, string>): void {
+        this.ensureComponent();
+
+        if (text) {
+            this.elementRef.nativeElement.classList.add("form-error-show");
+        } else {
+            this.elementRef.nativeElement.classList.remove("form-error-show");
+        }
+
+        this.ref!.instance.error = text.length > 0 ? this.translater(text, params) : text;
+    }
+
+    public setErrorText(text: string): void {
+        this.ensureComponent();
+
+        if (text) {
+            this.elementRef.nativeElement.classList.add("form-error-show");
+        } else {
+            this.elementRef.nativeElement.classList.remove("form-error-show");
+        }
+
+        this.ref!.instance.error = text;
+    }
+
+    private ensureComponent(): void {
+        if (this.ref) {
+            return;
+        }
+
+        this.ref = this.viewContainerRef.createComponent(NiceFormErrorComponent);
+        const wrapper = this.elementRef.nativeElement
+            .getElementsByClassName("mat-mdc-form-field-subscript-wrapper")
+            .item(0);
+
+        if (!wrapper) {
+            return;
+        }
+
+        const hint = this.elementRef.nativeElement.getElementsByClassName("mat-mdc-form-field-hint").item(0);
+        (this.ref.location.nativeElement as HTMLDivElement).style.position = "absolute";
+        (this.ref.location.nativeElement as HTMLDivElement).style.top = hint ? "16px" : "0";
+
+        if (hint) {
+            wrapper.classList.add("override-height");
+        }
+
+        wrapper.prepend(this.ref.location.nativeElement);
+    }
+}

--- a/src/material-components/form-field-error/form-field-error.directive.ts
+++ b/src/material-components/form-field-error/form-field-error.directive.ts
@@ -1,6 +1,5 @@
 import {
     AfterViewInit,
-    ComponentRef,
     DestroyRef,
     Directive,
     ElementRef,
@@ -13,9 +12,9 @@ import { MatFormField } from "@angular/material/form-field";
 import { NiceTranslater } from "@recursyve/ngx-material-components/common";
 import { combineLatest, startWith } from "rxjs";
 
-import { NiceFormErrorComponent } from "./form-field-error";
 import { ErrorTransformers } from "./error-transformer";
 import { NICE_FORM_FIELD_ERROR_TRANSFORMERS, NICE_FORM_FIELD_ERROR_TRANSLATER } from "./constant";
+import { FormFieldErrorDisplay } from "./form-field-error-display";
 
 @Directive({ selector: "[niceFormFieldError]", standalone: true })
 export class NiceFormFieldErrorDirective implements AfterViewInit {
@@ -26,7 +25,7 @@ export class NiceFormFieldErrorDirective implements AfterViewInit {
     private readonly transformers = inject<ErrorTransformers>(NICE_FORM_FIELD_ERROR_TRANSFORMERS);
     private readonly translater = inject<NiceTranslater>(NICE_FORM_FIELD_ERROR_TRANSLATER);
 
-    private ref: ComponentRef<NiceFormErrorComponent> | null = null ;
+    private readonly display = new FormFieldErrorDisplay(this.elementRef, this.viewContainerRef, this.translater);
     private control: NgControl | AbstractControlDirective | null = null;
 
     public onChange = () => {
@@ -35,25 +34,25 @@ export class NiceFormFieldErrorDirective implements AfterViewInit {
         }
 
         if (this.control.valid || this.control.untouched) {
-            this.setError("", {});
+            this.display.setError("", {});
             return;
         }
 
         for (const error in this.control.errors) {
             const details = this.control.errors[error];
             if (typeof details !== "object") {
-                this.setError(`errors.${error}`, {});
+                this.display.setError(`errors.${error}`, {});
                 continue;
             }
 
             const transformer = this.transformers[error];
             if (!transformer) {
-                this.setError(`errors.${error}`, {});
+                this.display.setError(`errors.${error}`, {});
                 continue;
             }
 
             const { key, params } = transformer(error, details);
-            this.setError(`errors.${key}`, params ?? {});
+            this.display.setError(`errors.${key}`, params ?? {});
         }
     }
 
@@ -70,31 +69,4 @@ export class NiceFormFieldErrorDirective implements AfterViewInit {
         }
     }
 
-    public setError(text: string, params: Record<string, string>): void {
-        if (!this.ref) {
-            this.ref = this.viewContainerRef.createComponent(NiceFormErrorComponent);
-            if (this.elementRef.nativeElement.getElementsByClassName("mat-mdc-form-field-subscript-wrapper").item(0)) {
-                const hint = this.elementRef.nativeElement.getElementsByClassName("mat-mdc-form-field-hint").item(0);
-                (this.ref.location.nativeElement as HTMLDivElement).style.position = "absolute";
-                (this.ref.location.nativeElement as HTMLDivElement).style.top = hint ? "16px" : "0";
-
-                const wrapper = this.elementRef.nativeElement
-                    .getElementsByClassName("mat-mdc-form-field-subscript-wrapper")
-                    .item(0);
-                if (hint) {
-                    wrapper.classList.add("override-height");
-                }
-
-                wrapper.prepend(this.ref.location.nativeElement);
-            }
-        }
-
-        if (text) {
-            this.elementRef.nativeElement.classList.add("form-error-show");
-        } else {
-            this.elementRef.nativeElement.classList.remove("form-error-show");
-        }
-
-        this.ref.instance.error = text.length > 0 ? this.translater(text, params) : text;
-    }
 }

--- a/src/material-components/form-field-error/index.ts
+++ b/src/material-components/form-field-error/index.ts
@@ -1,4 +1,5 @@
 export * from "./error-transformer";
 export * from "./form-field-error.directive";
+export * from "./signal-form-field-error.directive";
 export * from "./form-field-error";
 export * from "./provider";

--- a/src/material-components/form-field-error/options.ts
+++ b/src/material-components/form-field-error/options.ts
@@ -5,5 +5,15 @@ import { ErrorTransformers } from "./error-transformer";
 export type NiceFormFieldErrorsOptions = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     translater: Omit<FactoryProvider, "provide" | "multi"> & { useFactory: (...args: any[]) => NiceTranslater };
+    /**
+     * Transformers keyed by reactive form error name (e.g. `minlength`, `pattern`).
+     * Also used by signal forms when the `kind` matches or maps to the same key.
+     */
     errorTransformers?: ErrorTransformers;
+    /**
+     * Transformers keyed by signal form error `kind` (e.g. `minLength`, `reserved`).
+     * Takes priority over built-in signal-to-reactive conversion when no `message` is set
+     * on the validation error.
+     */
+    signalErrorTransformers?: ErrorTransformers;
 };

--- a/src/material-components/form-field-error/options.ts
+++ b/src/material-components/form-field-error/options.ts
@@ -5,15 +5,6 @@ import { ErrorTransformers } from "./error-transformer";
 export type NiceFormFieldErrorsOptions = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     translater: Omit<FactoryProvider, "provide" | "multi"> & { useFactory: (...args: any[]) => NiceTranslater };
-    /**
-     * Transformers keyed by reactive form error name (e.g. `minlength`, `pattern`).
-     * Also used by signal forms when the `kind` matches or maps to the same key.
-     */
     errorTransformers?: ErrorTransformers;
-    /**
-     * Transformers keyed by signal form error `kind` (e.g. `minLength`, `reserved`).
-     * Takes priority over built-in signal-to-reactive conversion when no `message` is set
-     * on the validation error.
-     */
     signalErrorTransformers?: ErrorTransformers;
 };

--- a/src/material-components/form-field-error/provider.ts
+++ b/src/material-components/form-field-error/provider.ts
@@ -9,7 +9,8 @@ export function provideFormFieldError(options: NiceFormFieldErrorsOptions): Prov
             provide: NICE_FORM_FIELD_ERROR_TRANSFORMERS,
             useValue: {
                 ...DefaultErrorTransformers,
-                ...options.errorTransformers
+                ...options.errorTransformers,
+                ...options.signalErrorTransformers
             }
         },
         {

--- a/src/material-components/form-field-error/signal-error-transformer.ts
+++ b/src/material-components/form-field-error/signal-error-transformer.ts
@@ -38,10 +38,20 @@ export function resolveSignalFormError(
     }
 
     const reactiveKey = SIGNAL_TO_REACTIVE_ERROR_KEY[error.kind] ?? error.kind;
-    const details = signalErrorToValidationErrors(error);
-    const transformer = transformers[error.kind] ?? transformers[reactiveKey];
+    const hasCustomTransformer = Object.hasOwn(transformers, error.kind);
+    const transformer = hasCustomTransformer
+        ? transformers[error.kind]
+        : transformers[reactiveKey];
 
-    if (typeof details !== "object" || !transformer) {
+    if (!transformer) {
+        return { text: `errors.${reactiveKey}`, params: {} };
+    }
+
+    const details = hasCustomTransformer
+        ? (error as ValidationErrors)
+        : signalErrorToValidationErrors(error);
+
+    if (typeof details !== "object") {
         return { text: `errors.${reactiveKey}`, params: {} };
     }
 

--- a/src/material-components/form-field-error/signal-error-transformer.ts
+++ b/src/material-components/form-field-error/signal-error-transformer.ts
@@ -1,0 +1,50 @@
+import { ValidationError } from "@angular/forms/signals";
+import { ValidationErrors } from "@angular/forms";
+
+import { DefaultErrorTransformers, ErrorTransformers } from "./error-transformer";
+
+const SIGNAL_TO_REACTIVE_ERROR_KEY: Record<string, string> = {
+    minLength: "minlength",
+    maxLength: "maxlength"
+};
+
+function signalErrorToValidationErrors(error: ValidationError.WithFieldTree): ValidationErrors {
+    const details = error as ValidationErrors;
+
+    switch (error.kind) {
+        case "minLength":
+            return { requiredLength: details["minLength"] };
+        case "maxLength":
+            return { requiredLength: details["maxLength"] };
+        case "pattern":
+            return { requiredPattern: String(details["pattern"] ?? "") };
+        default:
+            return details;
+    }
+}
+
+export const SignalDefaultErrorTransformers: ErrorTransformers = {
+    ...DefaultErrorTransformers,
+    minLength: (_, details) => DefaultErrorTransformers["minlength"]("minlength", details),
+    maxLength: (_, details) => DefaultErrorTransformers["maxlength"]("maxlength", details)
+};
+
+export function resolveSignalFormError(
+    error: ValidationError.WithFieldTree,
+    transformers: ErrorTransformers
+): { text: string; params: Record<string, string>; direct?: boolean } {
+    if (error.message) {
+        return { text: error.message, params: {}, direct: true };
+    }
+
+    const reactiveKey = SIGNAL_TO_REACTIVE_ERROR_KEY[error.kind] ?? error.kind;
+    const details = signalErrorToValidationErrors(error);
+    const transformer = transformers[error.kind] ?? transformers[reactiveKey];
+
+    if (typeof details !== "object" || !transformer) {
+        return { text: `errors.${reactiveKey}`, params: {} };
+    }
+
+    const { key, params } = transformer(reactiveKey, details);
+    return { text: `errors.${key}`, params: (params ?? {}) as Record<string, string> };
+}

--- a/src/material-components/form-field-error/signal-form-field-error.directive.ts
+++ b/src/material-components/form-field-error/signal-form-field-error.directive.ts
@@ -1,0 +1,99 @@
+import {
+    contentChild,
+    Directive,
+    effect,
+    ElementRef,
+    inject,
+    input,
+    ViewContainerRef
+} from "@angular/core";
+import { Field, FormField } from "@angular/forms/signals";
+import { MatFormField } from "@angular/material/form-field";
+import { NiceTranslater } from "@recursyve/ngx-material-components/common";
+
+import { NICE_FORM_FIELD_ERROR_TRANSFORMERS, NICE_FORM_FIELD_ERROR_TRANSLATER } from "./constant";
+import { ErrorTransformers } from "./error-transformer";
+import { FormFieldErrorDisplay } from "./form-field-error-display";
+import { resolveSignalFormError, SignalDefaultErrorTransformers } from "./signal-error-transformer";
+
+@Directive({ selector: "[niceSignalFormFieldError]", standalone: true })
+export class NiceSignalFormFieldErrorDirective {
+    private readonly elementRef = inject(ElementRef<HTMLElement>);
+    private readonly viewContainerRef = inject(ViewContainerRef);
+    private readonly formField = inject(MatFormField);
+    private readonly transformers = inject<ErrorTransformers>(NICE_FORM_FIELD_ERROR_TRANSFORMERS);
+    private readonly translater = inject<NiceTranslater>(NICE_FORM_FIELD_ERROR_TRANSLATER);
+
+    /**
+     * The signal form field to watch. When omitted, the directive resolves the `[formField]`
+     * binding from a descendant control inside the `mat-form-field`.
+     */
+    public readonly field = input<Field<unknown>>();
+
+    private readonly formFieldDirective = contentChild(FormField, { descendants: true });
+    private readonly display = new FormFieldErrorDisplay(this.elementRef, this.viewContainerRef, this.translater);
+    private readonly signalTransformers: ErrorTransformers = {
+        ...SignalDefaultErrorTransformers,
+        ...this.transformers
+    };
+
+    constructor() {
+        effect(() => {
+            this.onChange();
+        });
+    }
+
+    private onChange(): void {
+        const state = this.resolveFieldState();
+        if (state === null || state.pending()) {
+            return;
+        }
+
+        if (state.valid() || !state.touched()) {
+            this.display.setError("", {});
+            return;
+        }
+
+        const errors = this.resolveErrors(state.errors());
+
+        for (const error of errors) {
+            const resolved = resolveSignalFormError(error, this.signalTransformers);
+
+            if (resolved.direct) {
+                this.display.setErrorText(resolved.text);
+                continue;
+            }
+
+            this.display.setError(resolved.text, resolved.params);
+        }
+    }
+
+    private resolveFieldState() {
+        const fieldInput = this.field();
+        if (fieldInput) {
+            return fieldInput();
+        }
+
+        const formFieldDirective = this.formFieldDirective();
+        if (formFieldDirective) {
+            return formFieldDirective.state();
+        }
+
+        const ngControl = this.formField._control?.ngControl as { field?: Field<unknown> } | null;
+        if (ngControl?.field) {
+            return ngControl.field();
+        }
+
+        return null;
+    }
+
+    private resolveErrors(stateErrors: ReturnType<ReturnType<Field<unknown>>["errors"]>) {
+        const formFieldDirective = this.formFieldDirective();
+
+        if (formFieldDirective) {
+            return formFieldDirective.errors();
+        }
+
+        return stateErrors;
+    }
+}

--- a/src/material-components/form-field-error/signal-form-field-error.directive.ts
+++ b/src/material-components/form-field-error/signal-form-field-error.directive.ts
@@ -1,12 +1,4 @@
-import {
-    contentChild,
-    Directive,
-    effect,
-    ElementRef,
-    inject,
-    input,
-    ViewContainerRef
-} from "@angular/core";
+import { contentChild, Directive, effect, ElementRef, inject, input, ViewContainerRef } from "@angular/core";
 import { Field, FormField } from "@angular/forms/signals";
 import { MatFormField } from "@angular/material/form-field";
 import { NiceTranslater } from "@recursyve/ngx-material-components/common";
@@ -19,10 +11,10 @@ import { resolveSignalFormError, SignalDefaultErrorTransformers } from "./signal
 @Directive({ selector: "[niceSignalFormFieldError]", standalone: true })
 export class NiceSignalFormFieldErrorDirective {
     private readonly elementRef = inject(ElementRef<HTMLElement>);
-    private readonly viewContainerRef = inject(ViewContainerRef);
     private readonly formField = inject(MatFormField);
     private readonly transformers = inject<ErrorTransformers>(NICE_FORM_FIELD_ERROR_TRANSFORMERS);
     private readonly translater = inject<NiceTranslater>(NICE_FORM_FIELD_ERROR_TRANSLATER);
+    private readonly viewContainerRef = inject(ViewContainerRef);
 
     /**
      * The signal form field to watch. When omitted, the directive resolves the `[formField]`
@@ -39,33 +31,27 @@ export class NiceSignalFormFieldErrorDirective {
 
     constructor() {
         effect(() => {
-            this.onChange();
-        });
-    }
-
-    private onChange(): void {
-        const state = this.resolveFieldState();
-        if (state === null || state.pending()) {
-            return;
-        }
-
-        if (state.valid() || !state.touched()) {
-            this.display.setError("", {});
-            return;
-        }
-
-        const errors = this.resolveErrors(state.errors());
-
-        for (const error of errors) {
-            const resolved = resolveSignalFormError(error, this.signalTransformers);
-
-            if (resolved.direct) {
-                this.display.setErrorText(resolved.text);
-                continue;
+            const state = this.resolveFieldState();
+            if (state === null || state.pending()) {
+                return;
             }
 
-            this.display.setError(resolved.text, resolved.params);
-        }
+            if (state.valid() || !state.touched()) {
+                this.display.setError("", {});
+                return;
+            }
+
+            for (const error of this.resolveErrors(state.errors())) {
+                const resolved = resolveSignalFormError(error, this.signalTransformers);
+
+                if (resolved.direct) {
+                    this.display.setErrorText(resolved.text);
+                    continue;
+                }
+
+                this.display.setError(resolved.text, resolved.params);
+            }
+        });
     }
 
     private resolveFieldState() {
@@ -89,7 +75,6 @@ export class NiceSignalFormFieldErrorDirective {
 
     private resolveErrors(stateErrors: ReturnType<ReturnType<Field<unknown>>["errors"]>) {
         const formFieldDirective = this.formFieldDirective();
-
         if (formFieldDirective) {
             return formFieldDirective.errors();
         }


### PR DESCRIPTION
## Summary

- Add `NiceSignalFormFieldErrorDirective` (`niceSignalFormFieldError`) for Angular 22+ signal forms, mirroring the existing reactive forms `niceFormFieldError` behavior
- Extract shared error rendering into `FormFieldErrorDisplay` and reuse it in both directives
- Add signal-specific error mapping (`signal-error-transformer.ts`) so existing `provideFormFieldError` transformers and translater keep working
- Add `signalErrorTransformers` option for app-specific signal form error handling
- Extend the dev app with side-by-side demos for reactive and signal form field errors

## Usage

The directive auto-detects the `[formField]` binding inside the `mat-form-field`:

```html
<mat-form-field appearance="outline" niceSignalFormFieldError>
  <mat-label>Name</mat-label>
  <input matInput [formField]="signalForm.name" />
</mat-form-field>
```

Or accepts an explicit `[field]` input:

```html
<mat-form-field niceSignalFormFieldError [field]="signalForm.email">
  <input matInput [formField]="signalForm.email" />
</mat-form-field>
```

## Error transformation mechanism

Both directives follow the same pipeline:

```
Error detected → Transformer (optional) → i18n key + params → Translater → Displayed message
```

### Default transformers

Built-in transformers cover common reactive form errors (`required`, `minlength`, `maxlength`, `min`, `max`, `pattern`, `mask`). For signal forms, a conversion layer maps Angular `kind` values (`minLength`, `maxLength`, `pattern`, etc.) to the reactive format before applying those transformers. Unmapped errors fall back to `errors.{kind}`.

### Custom transformers

Applications can register their own transformers via `provideFormFieldError`:

```typescript
provideFormFieldError({
  translater: {
    useFactory: () => (key, params) => translate(key, params)
  },
  errorTransformers: {
    myCustomError: (_, details) => ({ key: "myCustomError", params: { ... } })
  },
  signalErrorTransformers: {
    reserved: (_, details) => ({
      key: "reserved",
      params: { value: String(details["reservedValue"]) }
    })
  }
})
```

Priority: `signalErrorTransformers` > `errorTransformers` > built-in defaults.

When a transformer is registered by exact `kind`, it receives the raw signal error object (with all custom properties), bypassing built-in conversion.

Validators can also return a `message` directly, which is displayed as-is without going through a transformer or translater.

The library produces an i18n key (`errors.{key}`) and params — the application's `translater` is responsible for rendering the final message.

https://github.com/user-attachments/assets/40b4d11a-e2a6-4553-9c8b-7beb37c5a6f6



https://github.com/user-attachments/assets/ec018cfe-84c9-4cbb-bd42-48a213fe2185

